### PR TITLE
Remove unused logging function

### DIFF
--- a/common/messages/messageTrace.go
+++ b/common/messages/messageTrace.go
@@ -10,7 +10,6 @@ KLUDGE: refactor to expose logging methods
 under original location inside messages package
 */
 var LogPrintf = log.LogPrintf
-var CheckFileName = log.CheckFileName
 var LogMessage = log.LogMessage
 
 type foo func(data []byte) (interfaces.IMsg, error)

--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -215,7 +215,7 @@ func startLiveFeed(w *worker.Thread, p *globals.FactomParams) {
 func startWebserver(w *worker.Thread) {
 	state0 := fnode.Get(0).State
 	wsapi.Start(w, state0)
-	if state0.DebugExec() && llog.CheckFileName("graphData.txt") {
+	if state0.DebugExec() && state0.CheckFileName("graphData.txt") {
 		go printGraphData("graphData.txt", 30)
 	}
 

--- a/log/log.go
+++ b/log/log.go
@@ -71,12 +71,6 @@ func LogMessage(name string, note string, msg interfaces.IMsg) {
 	GlobalLogger.Log(LogData{"logname": name, "comment": note, "message": msg})
 }
 
-// Check a filename and see if logging is on for that filename
-// If it never ben see then check with the regex. If it has been seen then just look it up in the map
-// assumes traceMutex is locked already
-
-func CheckFileName(name string) bool { return true } // hack for now
-
 func addmsg(msg interfaces.IMsg) {
 	msghistlock.Lock()
 	defer msghistlock.Unlock()


### PR DESCRIPTION
Seems like the Wax logging is mostly integrated and cleaning that whole thing up is beyond the scope of Dev/Wax merge, so this is just some cleanup to remove an unused function